### PR TITLE
ci: add ARM64 runners to test matrixFeature/add arm testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Linux x64
-          - os: ubuntu-24.04-arm64
+          - os: ubuntu-22.04-arm64
             name: Linux ARM64
           - os: macos-14
             name: macOS ARM64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - os: ubuntu-latest
             name: Linux x64
-          - os: ubuntu-22.04-arm64
+          - os: ubuntu-24.04-arm64
             name: Linux ARM64
           - os: macos-14
             name: macOS ARM64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,20 @@ permissions:
 
 jobs:
   install:
-    name: ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
-    runs-on: ${{matrix.os}}-latest
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        include:
+          - os: ubuntu-latest
+            name: Linux x64
+          - os: ubuntu-24.04-arm64
+            name: Linux ARM64
+          - os: macos-14
+            name: macOS ARM64
+          - os: windows-latest
+            name: Windows x64
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR addresses #12 by enabling CI testing on ARM64 architectures for Linux and macOS.

Added `ubuntu-24.04-arm64` and `macos-14` to the test matrix. I also switched to an `include` strategy to keep the job names cleaner in the dashboard.

Tested on my fork: x64 and macOS ARM are passing. Linux ARM is just pending a runner on my personal account, but the config is ready.