### PR TITLE
Allow pinning the DotSlash release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ jobs:
       - run: ./some_dotslash_file
 ```
 
+By default, the action installs the latest DotSlash release. To pin a release,
+pass the release tag:
+
+```yaml
+      - uses: facebook/install-dotslash@latest
+        with:
+          version: v0.5.9
+```
+
 ## License
 
 `install-dotslash` is MIT licensed, as found in the LICENSE file.

--- a/action.yml
+++ b/action.yml
@@ -5,14 +5,26 @@ branding:
   icon: activity
   color: purple
 
+inputs:
+  version:
+    description: DotSlash release tag to install. Defaults to the latest release.
+    required: false
+    default: latest
+
 runs:
   using: composite
   steps:
     - id: configure
       run: |
         platform=${{runner.os == 'macOS' && 'macos' || runner.os == 'Windows' && 'windows' || runner.arch == 'ARM64' && 'ubuntu-22.04.arm64' || 'ubuntu-22.04.x86_64'}}
+        requested_version="${DOTSLASH_VERSION:-latest}"
+        if [ "$requested_version" = "latest" ]; then
+          release_url="https://api.github.com/repos/facebook/dotslash/releases/latest"
+        else
+          release_url="https://api.github.com/repos/facebook/dotslash/releases/tags/${requested_version}"
+        fi
         release_json="${{runner.temp}}/install-dotslash-release.json"
-        curl https://api.github.com/repos/facebook/dotslash/releases/latest \
+        curl "$release_url" \
         --header "authorization: Bearer ${{ github.token }}" \
         --output "$release_json" \
         --location --silent --show-error --fail --retry 5
@@ -43,6 +55,8 @@ runs:
         echo asset="$asset" >> $GITHUB_OUTPUT
         echo digest="$digest" >> $GITHUB_OUTPUT
       shell: bash
+      env:
+        DOTSLASH_VERSION: ${{ inputs.version }}
 
     - run: mkdir -p "${{runner.temp}}/install-dotslash/bin"
       shell: bash


### PR DESCRIPTION
## Summary
- Add an optional `version` input that defaults to `latest`.
- Resolve pinned installs through the GitHub releases `tags/<version>` API while preserving the existing latest-release path.
- Document the release-tag pinning syntax in the README.

Fixes #10.

## Validation
- YAML parse check confirmed `inputs.version.default == latest`.
- `git diff --check`
- Resolved release metadata against the real GitHub API:
  - `latest` -> `v0.5.9`, `dotslash-ubuntu-22.04.x86_64.v0.5.9.tar.gz`, expected digest found
  - `v0.5.8` -> `dotslash-windows.v0.5.8.tar.gz`, expected digest found
- Downloaded `dotslash-windows.v0.5.8.tar.gz`, verified SHA-256 `736c1d3c37e7ce98904c4bf7fea025da5337b183d8e64d81697591ab2beabd43`, extracted `dotslash.exe`, and confirmed `dotslash.exe --version` prints `DotSlash 0.5.8`.
